### PR TITLE
feat: transfer page and update misc. missing features

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,13 +1,13 @@
-import React, { cloneElement, createElement, useContext, useState } from 'react'
-import { useLocation } from 'react-router-dom'
+import React, { useContext, useState } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
 import { Container } from '../Layout'
-import { FeedLeft, HeaderWrapper, ProfileImage, SocialFeedText } from './styles'
-import { DiscordMediaIcon, IAMMTextIcon, MetaMaskIcon, TwitterMediaIcon } from '../Svg'
+import { FeedLeft, HeaderWrapper, ImpactButton, ProfileImage, SocialFeedText } from './styles'
+import { DiscordMediaIcon, IAMMTextIcon, LeftArrowIcon, TwitterMediaIcon } from '../Svg'
 import { Box, Flex } from '../Box'
 import Hamburger from 'hamburger-react'
 import { Context } from '../../contexts/UserProfile'
-import { Button } from '../Button'
 import MainMenu from '../MainMenu/MainMenu'
+import { ROUTES } from '../../pages/RoutesData'
 
 const socialMedia = () => (
   <Flex>
@@ -32,10 +32,13 @@ const hamburguerMenu = (color: string, toggled: boolean, toggle: React.Dispatch<
 
 const Header: React.FC = () => {
   const { pathname } = useLocation()
+  const navigate = useNavigate();
   const [isOpen, setIsOpen] = useState(false)
   const { isConnected, setIsConnected, networkId } = useContext(Context)
 
-  const isFeed = pathname === '/feed'
+  const isPurple = pathname === ROUTES.FEED || pathname === ROUTES.SHARE_POST
+  const isFeed = pathname === ROUTES.FEED
+  const isSharePost = pathname === ROUTES.SHARE_POST
 
   const getRender = (): boolean => {
     if (pathname === '/testnet/collection/iamm') return false
@@ -88,7 +91,7 @@ const Header: React.FC = () => {
   if (pathname !== '/testnet/profile-dashboard')
     return (
       <>
-        <HeaderWrapper isFeed={isFeed} main={getRender() && isConnected}>
+        <HeaderWrapper isPurple={isPurple} main={getRender() && isConnected}>
           <Container maxWidth='90%'>
             <Flex alignItems='center' justifyContent='space-between' width='100%'>
               {isFeed ? (
@@ -96,6 +99,15 @@ const Header: React.FC = () => {
                   <ProfileImage src='/profile-1.png' alt='profile-image' />
                   <SocialFeedText>Social Feed</SocialFeedText>
                 </FeedLeft>
+              ) : isSharePost ? (
+                <Flex alignItems={'center'} width={'100%'} justifyContent={'space-between'}>
+                  <FeedLeft>
+                    <div style={{ cursor: 'pointer' }} onClick={() => navigate(-1)}>
+                      <LeftArrowIcon width='15px' height='15px' />
+                    </div>
+                  </FeedLeft>
+                  <ImpactButton>Impact</ImpactButton>
+                </Flex>
               ) : (
                 <>
                   <IAMMTextIcon onClick={() => window.location.reload()} width='100px' fill='white' />

--- a/src/components/Header/styles/index.ts
+++ b/src/components/Header/styles/index.ts
@@ -1,11 +1,11 @@
 import styled from 'styled-components'
 import { Box } from '../../Box'
 
-export const HeaderWrapper = styled(Box)<{ main?: boolean; isFeed: boolean }>`
+export const HeaderWrapper = styled(Box)<{ main?: boolean; isPurple: boolean }>`
   align-items: center;
-  background-color: ${({ main, isFeed }) => (main ? '#8B40F4' : isFeed ? '#180a33' : '#1A1A1A')};
+  background-color: ${({ main, isPurple }) => (main ? '#8B40F4' : isPurple ? '#180a33' : '#1A1A1A')};
   display: flex;
-  height: ${({ isFeed }) => (isFeed ? '60px' : '80px')};
+  height: ${({ isPurple }) => (isPurple ? '60px' : '80px')};
   position: fixed;
   width: 100vw;
   z-index: 100;
@@ -33,6 +33,16 @@ export const FeedLeft = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
+`
+
+export const ImpactButton = styled.button`
+  background: #8b40f4;
+  border-radius: 12px;
+  padding: 6px 12px;
+  font-weight: 600;
+  color: white;
+  border: none;
+  cursor: pointer;
 `
 
 /** Items */

--- a/src/pages/NFTViewer/NFTViewer.tsx
+++ b/src/pages/NFTViewer/NFTViewer.tsx
@@ -17,11 +17,9 @@ const TempImage = require('../../assets/images/congrats-img.png')
 export type modalMode = 'buyer' | 'owner' | 'putOnSale' | 'acceptOffer' | 'transfer' | 'cancel'
 
 const NFTViewer = ({ name, contract, imageCid, mode }: { name: string; contract: string; imageCid: string, mode: 'buyer' | 'owner' }) => {
-  const [openMenu,  setOpenMenu] = useState(false)
   const [modalMode, setModalMode] = useState<modalMode>(mode)
 
   const handleOverlay = () => {
-    setOpenMenu(false)
     setModalMode(mode)
   }
 
@@ -67,7 +65,7 @@ const NFTViewer = ({ name, contract, imageCid, mode }: { name: string; contract:
                     </Flex>
                   </Flex>
               </Flex>
-              <AcceptOfferButton onClick={() => setOpenMenu(prev => !prev)}>{mode === 'buyer' ? 'MAKE OFFER' :  'ACCEPT OFFER'}</AcceptOfferButton>
+              <AcceptOfferButton onClick={() => setModalMode(mode === 'buyer' ? 'buyer' : 'acceptOffer')}>{mode === 'buyer' ? 'MAKE OFFER' :  'ACCEPT OFFER'}</AcceptOfferButton>
             </Offer>
             <Accordion title="Description">
               Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore.
@@ -105,8 +103,8 @@ const NFTViewer = ({ name, contract, imageCid, mode }: { name: string; contract:
         </Flex>
       </Container>
       <Menu />
-      {openMenu && <BottomMenu mode={modalMode} setModalMode={setModalMode}/>}
-      {openMenu && (modalMode === 'transfer' || modalMode === 'putOnSale') && <Overlay onClick={handleOverlay}/>}
+      <BottomMenu mode={modalMode} setModalMode={setModalMode}/>
+      {(modalMode === 'transfer' || modalMode === 'putOnSale') && <Overlay onClick={handleOverlay}/>}
     </>
   )
 }

--- a/src/pages/NFTViewer/components/BottomMenu.tsx
+++ b/src/pages/NFTViewer/components/BottomMenu.tsx
@@ -1,102 +1,112 @@
-import { PropsWithChildren, useState } from 'react';
-import styled from 'styled-components';
-import { Flex } from '../../../components/Box';
-import { randomIntFromInterval } from '../../SocialFeed/data/types';
-import { modalMode } from '../NFTViewer';
-import { Text } from '../styles';
+import { PropsWithChildren, useState } from 'react'
+import { Link } from 'react-router-dom'
+import styled from 'styled-components'
+import { Flex } from '../../../components/Box'
+import { ROUTES } from '../../RoutesData'
+import { randomIntFromInterval } from '../../SocialFeed/data/types'
+import { modalMode } from '../NFTViewer'
+import { Text } from '../styles'
 
 interface BottomMenuProps {
-  mode: modalMode;
-  setModalMode: (mode: modalMode) => void;
+  mode: modalMode
+  setModalMode: (mode: modalMode) => void
 }
 
 const TempImage = require('../../../assets/images/congrats-img.png')
 
 export default function BottomMenu({ mode, setModalMode }: PropsWithChildren<BottomMenuProps>) {
-    const [price, setPrice] = useState(0);
+  const [price, setPrice] = useState(0)
 
-    const handlePriceChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        setPrice(Number(e.target.value));
-    };
+  const handlePriceChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setPrice(Number(e.target.value))
+  }
 
-    return mode === 'buyer' ? (
+  return mode === 'buyer' ? (
     <Wrapper>
-        <PrimaryButton>BUY NOW</PrimaryButton>
-        <SecondaryButton>ADD TO WATCHLIST</SecondaryButton>
+      <PrimaryButton>BUY NOW</PrimaryButton>
+      <SecondaryButton>ADD TO WATCHLIST</SecondaryButton>
     </Wrapper>
-    ) : mode === 'owner' ? (
+  ) : mode === 'owner' ? (
     <Wrapper>
-        <PrimaryButton onClick={() => setModalMode('putOnSale')}>PUT ON SALE</PrimaryButton>
+      <PrimaryButton onClick={() => setModalMode('putOnSale')}>PUT ON SALE</PrimaryButton>
+      <SecondaryButton onClick={() => setModalMode('transfer')}>TRANSFER NOW</SecondaryButton>
+    </Wrapper>
+  ) : mode === 'putOnSale' ? (
+    <Wrapper>
+      <Flex flexDirection={'column'}>
+        <Text size='18px' weight={600}>
+          Put on Sale
+        </Text>
+        <Flex flexDirection={'column'} maxWidth={540} marginTop={10} marginBottom={20}>
+          <Text size='12px' weight={400} style={{ textAlign: 'left' }}>
+            SET SALE PRICE
+          </Text>
+          <PriceInputContainer>
+            <Tag>pCKB</Tag>
+            <PriceInpput name='input' value={price} onChange={handlePriceChange} type={'number'} />
+          </PriceInputContainer>
+          <Text size='12px' weight={400} style={{ textAlign: 'right' }}>
+            ${price * 0.001}
+          </Text>
+        </Flex>
+        <Flex>
+          <RedButton onClick={() => setModalMode('owner')}>x</RedButton>
+          <GreenButton onClick={() => setModalMode('owner')}>✓</GreenButton>
+        </Flex>
+      </Flex>
+    </Wrapper>
+  ) : mode === 'cancel' ? (
+    <Wrapper>
+      <Flex>
+        <RedButton onClick={() => setModalMode('owner')}>Cancel</RedButton>
         <SecondaryButton onClick={() => setModalMode('transfer')}>TRANSFER NOW</SecondaryButton>
-    </Wrapper> 
-    ) : mode === 'putOnSale' ? (
-    <Wrapper>
-        <Flex flexDirection={'column'}>
-            <Text size="18px" weight={600}>Put on Sale</Text>
-            <Flex flexDirection={'column'} maxWidth={540} marginTop={10} marginBottom={20}>
-                <Text size="12px" weight={400} style={{ textAlign: 'left' }}>SET SALE PRICE</Text>
-                <PriceInputContainer>
-                    <Tag>pCKB</Tag>
-                    <PriceInpput name="input" value={price} onChange={handlePriceChange} type={'number'} />
-                </PriceInputContainer>
-                <Text size="12px" weight={400} style={{ textAlign: 'right' }}>${price * 0.001}</Text>
-            </Flex>
-            <Flex>
-                <RedButton onClick={() => setModalMode('owner')}>x</RedButton>
-                <GreenButton onClick={() => setModalMode('owner')}>✓</GreenButton>
-            </Flex>
-        </Flex>
+      </Flex>
     </Wrapper>
-    ) : mode === 'cancel' ? (
+  ) : mode === 'acceptOffer' ? (
     <Wrapper>
+      <Flex>
+        <RedButton onClick={() => setModalMode('owner')}>MAYBE NOT</RedButton>
+        <GreenButton onClick={() => setModalMode('owner')}>I'M SURE</GreenButton>
+      </Flex>
+    </Wrapper>
+  ) : mode === 'transfer' ? (
+    <Wrapper>
+      <Flex flexDirection={'column'} width={'100%'} padding='0 10px' alignItems={'center'}>
+        <Text size='18px' weight={600}>
+          Transfer
+        </Text>
+        <Flex flexDirection={'column'} maxWidth={540} marginTop={10} marginBottom={20} width={'100%'}>
+          <img style={{ margin: '10px auto 40px auto' }} src={TempImage} width={160} height={160} alt='nft-asset' />
+          <Flex flexDirection={'column'} style={{ width: '100%' }} width={'100%'}>
+            <Text style={{ textAlign: 'left' }} size='12px' weight={400}>
+              TRANSFER &quot;libreNFT #${randomIntFromInterval(0, 10000)}&quot; to:
+            </Text>
+            <TransferInpput name='input' placeholder='e.g. ckb1qz... or @handle, or destination.eth/.lens' type={'text'} />
+          </Flex>
+        </Flex>
         <Flex>
-            <RedButton onClick={() => setModalMode('owner')}>Cancel</RedButton>
-            <SecondaryButton onClick={() => setModalMode('transfer')}>TRANSFER NOW</SecondaryButton>
+          <RedButton style={{ width: 'fit-content' }} onClick={() => setModalMode('owner')}>
+            NOT NOW
+          </RedButton>
+          <Link style={{ textDecoration: 'none' }} to={ROUTES.TRANSFER_SUCCESS}>
+            <GreenButton style={{ width: 'fit-content' }}>CONFIRM</GreenButton>
+          </Link>
         </Flex>
+      </Flex>
     </Wrapper>
-    ) : mode === 'acceptOffer' ? (
-    <Wrapper>
-        <Flex>
-            <RedButton onClick={() => setModalMode('owner')}>MAYBE NOT</RedButton>
-            <GreenButton onClick={() => setModalMode('owner')}>I'M SURE</GreenButton>
-        </Flex>
-    </Wrapper>
-    ) : mode === 'transfer' ? (
-    <Wrapper>
-        <Flex flexDirection={'column'} width={'100%'} padding="0 10px" alignItems={'center'}>
-            <Text size="18px" weight={600}>Transfer</Text>
-            <Flex flexDirection={'column'} maxWidth={540} marginTop={10} marginBottom={20} width={'100%'}>
-                <img style={{ margin: '10px auto 40px auto' }} src={TempImage} width={160} height={160} alt='nft-asset' />
-                <Flex flexDirection={'column'} style={{ width: '100%' }} width={'100%'}> 
-                    <Text style={{ textAlign: 'left' }} size="12px" weight={400}>
-                        TRANSFER &quot;libreNFT #${randomIntFromInterval(0, 10000)}&quot; to:
-                    </Text>
-                    <TransferInpput 
-                        name="input"
-                        placeholder='e.g. ckb1qz... or @handle, or destination.eth/.lens'
-                        type={'text'} 
-                    />
-                </Flex>
-            </Flex>
-            <Flex>
-                <RedButton style={{ width: 'fit-content' }} onClick={() => setModalMode('owner')}>NOT NOW</RedButton>
-                <GreenButton style={{ width: 'fit-content' }} onClick={() => setModalMode('owner')}>CONFIRM</GreenButton>
-            </Flex>
-        </Flex>
-    </Wrapper>
-    ) : null;
+  ) : null
 }
 
 const Wrapper = styled.div`
   display: flex;
   justify-content: center;
-  background: #1A1A1A;
+  background: #1a1a1a;
   position: fixed;
   bottom: 60px;
   width: 100%;
   padding: 15px;
   z-index: 20000;
-`;
+`
 
 const PrimaryButton = styled.button`
   display: flex;
@@ -107,7 +117,7 @@ const PrimaryButton = styled.button`
   justify-content: center;
   align-items: center;
   padding: 4px 26px;
-  background: #8B40F4;
+  background: #8b40f4;
   border-radius: 11px;
   border: none;
   margin-inline: 15px;
@@ -116,32 +126,33 @@ const PrimaryButton = styled.button`
 
 const SecondaryButton = styled(PrimaryButton)`
   background: transparent;
-  border: 1px solid #8B40F4;
-  color: #8B40F4;
-`;
+  border: 1px solid #8b40f4;
+  color: #8b40f4;
+`
 
 const RedButton = styled(PrimaryButton)`
-  background: #F4404F;
+  background: #f4404f;
   font-weight: 600;
   font-size: 18px;
-`;
+`
 
 const GreenButton = styled(PrimaryButton)`
-  background: #40F48B;
+  background: #40f48b;
   font-weight: 600;
   font-size: 18px;
-`;
+  text-decoration: none;
+`
 
 const PriceInputContainer = styled.div`
   display: flex;
   height: 45px;
-  color: #8B40F4;
+  color: #8b40f4;
   justify-content: center;
   align-items: center;
-  border: 1px solid #8B40F4;
+  border: 1px solid #8b40f4;
   border-radius: 8px;
   margin-block: 10px;
-`;
+`
 
 const Tag = styled.div`
   display: flex;
@@ -150,11 +161,11 @@ const Tag = styled.div`
   justify-content: center;
   align-items: center;
   padding: 4px 26px;
-  border-right: 1px solid #8B40F4;
+  border-right: 1px solid #8b40f4;
   margin-block: 10px;
   text-align: center;
   width: 30%;
-`;
+`
 
 const PriceInpput = styled.input`
   display: flex;
@@ -173,7 +184,7 @@ const PriceInpput = styled.input`
   &:focus {
     outline: none;
   }
-`;
+`
 
 const TransferInpput = styled.input`
   display: flex;
@@ -183,7 +194,7 @@ const TransferInpput = styled.input`
   border: none;
   height: 45px;
   text-align: left;
-  border: 1px solid #8B40F4;
+  border: 1px solid #8b40f4;
   border-radius: 8px;
   padding: 5px 12px;
   width: 100%;
@@ -195,4 +206,4 @@ const TransferInpput = styled.input`
   &:focus {
     outline: none;
   }
-`;
+`

--- a/src/pages/RoutesData.tsx
+++ b/src/pages/RoutesData.tsx
@@ -8,6 +8,18 @@ import { SocialFeed } from './SocialFeed'
 import ShowThisThread from './ShowThisThread/ShowThisThread'
 import NFTViewer from './NFTViewer/NFTViewer'
 import SharePost from './Share/SharePost'
+import TransferSuccess from './TranferSuccess/TransferSuccess'
+
+export const ROUTES = {
+  HOME: '/',
+  FEED: '/testnet/feed',
+  THREAD: '/testnet/feed/show-this-thread/:thread_id',
+  CREATE_SINGLE_NFT: '/testnet/create-single-nft',
+  NFT_VIEWER_OWNER: '/testnet/viewer-owner-LNFT',
+  NFT_VIEWER_BUYER: '/testnet/viewer-buyer-LNFT',
+  SHARE_POST: '/testnet/impact-shareLNFT',
+  TRANSFER_SUCCESS: '/testnet/viewer-owner-transferLNFT',
+}
 
 export const RoutesData = [
   {
@@ -32,11 +44,11 @@ export const RoutesData = [
   },
   {
     view: <SocialFeed />,
-    path: 'testnet/feed',
+    path: ROUTES.FEED,
   },
   {
     view: <ShowThisThread />,
-    path: 'testnet/feed/show-this-thread/:thread_id',
+    path: ROUTES.THREAD,
   },
   {
     view: <Handle />,
@@ -44,14 +56,18 @@ export const RoutesData = [
   },
   {
     view: <NFTViewer mode="owner" />,
-    path: 'testnet/viewer-owner-LNFT',
+    path: ROUTES.NFT_VIEWER_OWNER,
   },
   {
     view: <NFTViewer mode="buyer"/>,
-    path: 'testnet/viewer-buyer-LNFT',
+    path: ROUTES.NFT_VIEWER_BUYER,
   },
   {
     view: <SharePost/>,
-    path: 'testnet/impact-shareLNFT',
+    path: ROUTES.SHARE_POST,
+  },
+  {
+    view: <TransferSuccess/>,
+    path: ROUTES.TRANSFER_SUCCESS,
   },
 ]

--- a/src/pages/Share/component/Post.tsx
+++ b/src/pages/Share/component/Post.tsx
@@ -14,6 +14,7 @@ const Container = styled.div`
 const Wrapper = styled.div`
   display: flex;
   margin-top: 10px;
+  gap: 10px;
 `
 
 const Left = styled.div`
@@ -49,12 +50,11 @@ const TextArea = styled.textarea`
   background: transparent;
   border: none;
   resize: none;
-  padding-block: 15px;
   width: 100%;
   border: none;
   overflow: auto;
   outline: none;
-  min-height: 100px;
+  min-height: 140px;
   margin-bottom: 20px;
 
   -webkit-box-shadow: none;
@@ -107,12 +107,20 @@ const ArrowIcon = styled.div<{ isActive: boolean }>`
   margin-left: 5px;
 `;
 
-const MAX_CHARACTERS = 100
+const MAX_CHARACTERS = 150
 
 const TempImage = require('../../../assets/images/congrats-img.png')
 
+const DEFAULT_TEXT = `
+Hello everyone! 
+
+I’ve recently created libreNFT #0888 in the IAMM platform. 
+
+Check it out!
+`
+
 export default function Post({ item }: { item: PostProps }) {
-  const [text, setText] = useState('')
+  const [text, setText] = useState(DEFAULT_TEXT)
   const [openType, setOpenType] = useState(false)
 
   const handleInput = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -128,20 +136,22 @@ export default function Post({ item }: { item: PostProps }) {
           <ProfileImage src={item.profile} alt='profile' />
         </Left>
         <Right>
-          <Type onClick={() => setOpenType(prev => !prev)}>
-            Everyone
-            <ArrowIcon isActive={openType}>
-              <svg
-                viewBox="0 0 20 20"
-                focusable="false"
-                aria-hidden="true"
-                preserveAspectRatio="none"
-              >
-                <path fill="#8B40F4" d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"></path>
-              </svg>
-            </ArrowIcon>
-          </Type>
-          <TextArea value={text} onChange={handleInput} placeholder='What are your thoughts?' />
+          <Flex paddingBottom={10}>
+            <Type onClick={() => setOpenType(prev => !prev)}>
+              Everyone
+              <ArrowIcon isActive={openType}>
+                <svg
+                  viewBox="0 0 20 20"
+                  focusable="false"
+                  aria-hidden="true"
+                  preserveAspectRatio="none"
+                >
+                  <path fill="#8B40F4" d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"></path>
+                </svg>
+              </ArrowIcon>
+            </Type>
+          </Flex>
+          <TextArea value={text} onChange={handleInput} maxLength={MAX_CHARACTERS} placeholder='What are your thoughts?' />
           <img src={TempImage} alt='nft-asset' />
           <Permission>
             <EarthIcon  width='14px' height='14px' />

--- a/src/pages/SocialFeed/components/Post.tsx
+++ b/src/pages/SocialFeed/components/Post.tsx
@@ -3,6 +3,7 @@ import { PostProps } from '../data/types'
 import TimeAgo from 'timeago-react'
 import { HeartIcon, MessageIcon, NervosIcon, SpeechBubbleIcon, RetweetIcon, ShareIcon } from '../../../components/Svg'
 import { Link } from 'react-router-dom'
+import { ROUTES } from '../../RoutesData'
 
 const Container = styled.div`
   margin-top: 30px;
@@ -207,7 +208,7 @@ export default function Post({ item }: { item: PostProps }) {
               </TipItem>
             )}
           </Footer>
-          {item.threads.length > 0 && <ThreadText to='/testnet/feed/show-this-thread/1'>Show this thread</ThreadText>}
+          {item.threads.length > 0 && <ThreadText to={ROUTES.THREAD}>Show this thread</ThreadText>}
         </Right>
       </Wrapper>
     </Container>

--- a/src/pages/TranferSuccess/TransferSuccess.tsx
+++ b/src/pages/TranferSuccess/TransferSuccess.tsx
@@ -1,0 +1,35 @@
+import { Link, useNavigate } from 'react-router-dom'
+import { Flex, Box } from '../../components/Box'
+import { ROUTES } from '../RoutesData'
+import { Title, Wrapper, Text, ContinueButton } from './style'
+
+const TempImage = require('../../assets/images/congrats-img.png')
+
+const TransferSuccess = () => {
+  const navigate = useNavigate()
+  return (
+    <Wrapper justifyContent='center'>
+      <Flex paddingTop={'80px'} flexDirection='column' alignContent='center' alignItems={'center'}>
+        <Box padding='1rem'>
+          <Title>Transfer Success!</Title>
+        </Box>
+
+        <Box marginY='1rem'>
+          <img width={160} height={160} src={TempImage} alt='nft-asset' />
+        </Box>
+
+        <Box style={{ marginTop: '20px', marginBottom: '20px' }}>
+          <Text style={{ marginBottom: '20px', fontWeight: '600' }}>&quot;libreNFT #0888&quot;</Text>
+          <Text style={{ marginBottom: '20px' }}>successfully transferred to</Text>
+          <Text style={{ marginBottom: '20px', fontWeight: '600' }}>@handle!</Text>
+        </Box>
+
+        <Link to={ROUTES.HOME}>
+        <ContinueButton>Continue</ContinueButton>
+        </Link>
+      </Flex>
+    </Wrapper>
+  )
+}
+
+export default TransferSuccess

--- a/src/pages/TranferSuccess/style/index.ts
+++ b/src/pages/TranferSuccess/style/index.ts
@@ -1,0 +1,53 @@
+import styled from 'styled-components'
+import { Flex } from '../../../components/Box'
+
+export const Wrapper = styled(Flex)`
+  width: 100%;
+  height: 100vh;
+  background: #1a1a1a;
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 1000;
+  overflow-x: hidden;
+  overflow-y: scroll;
+`
+
+export const Title = styled.h1`
+  font-size: 21px;
+  color: white;
+  font-weight: 600;
+
+  a {
+    color: white;
+    font-size: 21px;
+    text-decoration: none;
+    font-weight: 600;
+  }
+`
+
+export const Text = styled.div`
+  font-size: 12px;
+  color: white;
+  font-weight: 400;
+
+  a {
+    color: white;
+    font-size: 12px;
+    text-decoration: none;
+    font-weight: 400;
+  }
+`
+
+export const ContinueButton = styled.button`
+  background: #8b40f4;
+  border-radius: 12px;
+  padding: 6px 12px;
+  font-weight: 600;
+  width: 120px;
+  height: 45px;
+  font-size: 18px;
+  color: white;
+  border: none;
+  cursor: pointer;
+`


### PR DESCRIPTION
1. Add transfer success page
<img width="368" alt="Screenshot 2023-04-08 at 12 38 31 AM" src="https://user-images.githubusercontent.com/41753422/230636724-d549d67d-c4f6-478e-ab7b-eac0036a3140.png">

2. Suggested the route URLs as below

```
export const ROUTES = {
  HOME: '/',
  FEED: '/testnet/feed',
  THREAD: '/testnet/feed/show-this-thread/:thread_id',
  CREATE_SINGLE_NFT: '/testnet/create-single-nft',
  NFT_VIEWER_OWNER: '/testnet/viewer-owner-LNFT',
  NFT_VIEWER_BUYER: '/testnet/viewer-buyer-LNFT',
  SHARE_POST: '/testnet/impact-shareLNFT',
  TRANSFER_SUCCESS: '/testnet/viewer-owner-transferLNFT',
}
```

so that the variable names can be used in other components in the same manner.

3. Update misc. things based on the Notion feedback.
- Default text for share post
- Impact button on the share post screen
- bottom menu appears by default