### PR TITLE
store contract address and user address to sessionStorage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,15 +2,16 @@ import { FC, useCallback, useContext, useEffect } from 'react'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 
 import { Header } from './components/Header'
-import { RoutesData } from './pages/RoutesData'
+import { ROUTES, RoutesData } from './pages/RoutesData'
 
 import './App.css'
 import { Context as UserProfile } from './contexts/UserProfile'
 import ScrollToTop from './util/scrollToTop'
+import ProfileService from './services/Profiles'
 
 const App: FC = () => {
   /// METAMASK
-  const { setNetworkId } = useContext(UserProfile)
+  const { setNetworkId, setIsConnected, setUserAddress, setUserProfilePic, setHandle } = useContext(UserProfile)
 
   const getNetworkId = useCallback(() => {
     if (typeof window.ethereum !== 'undefined') {
@@ -23,7 +24,35 @@ const App: FC = () => {
     getNetworkId()
   }, [getNetworkId])
 
-  useEffect(() => {})
+  const getAccounts = useCallback(async () => {
+    const sessionUserAddress = sessionStorage.getItem('userAddress')
+    const addresses = sessionUserAddress != null && JSON.parse(sessionUserAddress)
+
+    let accounts: string[]
+    accounts = addresses?.length ? addresses : await window.ethereum.request({ method: 'eth_requestAccounts' })
+
+    if (!addresses?.length) {
+      sessionStorage.setItem('userAddress', JSON.stringify(accounts))
+    }
+
+    if (accounts.length > 0) {
+      setIsConnected(true)
+      setUserAddress(accounts[0])
+
+      const usrProfile = await ProfileService.getProfile(accounts[0])
+
+      if (usrProfile.status === 'ok') {
+        setUserProfilePic(usrProfile.data.imageURI)
+        setHandle(usrProfile.data.handle)
+      }
+    }
+
+    return accounts
+  }, [setIsConnected, setUserProfilePic, setUserAddress])
+
+  useEffect(() => {
+    getAccounts()
+  }, [getAccounts])
 
   useEffect(() => {
     if (typeof window.ethereum !== 'undefined') {

--- a/src/components/MainMenu/BottomSection/index.tsx
+++ b/src/components/MainMenu/BottomSection/index.tsx
@@ -4,8 +4,8 @@ import styled from 'styled-components'
 import AdditionalMenu from './AdditionalMenu'
 import WalletConnect from './WalletConnect'
 import { ROUTES } from '../../../pages/RoutesData'
-import { useNavigate } from "react-router-dom"
-import {CommonLinkSectionProps} from '../LinksSection'
+import { useNavigate } from 'react-router-dom'
+import { CommonLinkSectionProps } from '../LinksSection'
 import ProfileService from '../../../services/Profiles'
 
 const SectionWrapper = styled.div`
@@ -20,32 +20,37 @@ const SectionWrapper = styled.div`
 const BottomSection: React.FC<CommonLinkSectionProps> = (props: CommonLinkSectionProps) => {
   const navigate = useNavigate()
 
-  const { isConnected, setIsConnected, networkId, userProfilePic, setUserProfilePic, userAddress, setUserAddress, handle, setHandle } = useContext(Context)
+  const { isConnected, setIsConnected, networkId, userProfilePic, setUserProfilePic, userAddress, setUserAddress, handle, setHandle } =
+    useContext(Context)
   const [accounts, setAccounts] = useState<string[]>([])
   const REQUIRED_NETWORK_ID = 71401
 
   const getAccounts = useCallback(async () => {
+    const sessionUserAddress = sessionStorage.getItem('userAddress')
+    const addresses = sessionUserAddress != null && JSON.parse(sessionUserAddress)
 
-    const accounts: string[] = await window.ethereum.request({ method: 'eth_requestAccounts' })
-    console.log('accounts')
-    console.log(accounts)
+    let accounts: string[]
+    accounts = addresses?.length ? addresses : await window.ethereum.request({ method: 'eth_requestAccounts' })
+
+    if (!addresses?.length) {
+      sessionStorage.setItem('userAddress', JSON.stringify(accounts))
+    }
 
     if (accounts.length > 0) {
+      setAccounts(accounts)
+      setIsConnected(true)
+      setUserAddress(accounts[0])
 
-      setAccounts(accounts);
-      setIsConnected(true);
-      setUserAddress(accounts[0]);
+      const usrProfile = await ProfileService.getProfile(accounts[0])
 
-      const usrProfile = await ProfileService.getProfile(accounts[0]);
-
-      if(usrProfile.status === 'ok'){
-        setUserProfilePic(usrProfile.data.imageURI);
+      if (usrProfile.status === 'ok') {
+        setUserProfilePic(usrProfile.data.imageURI)
         setHandle(usrProfile.data.handle)
-        props?.toggle?.(false);
+        props?.toggle?.(false)
       } else {
-        props?.toggle?.(false);
-        navigate(ROUTES.PROFILE_DASHBOARD);
-      }      
+        props?.toggle?.(false)
+        navigate(ROUTES.PROFILE_DASHBOARD)
+      }
     }
 
     return accounts
@@ -56,7 +61,7 @@ const BottomSection: React.FC<CommonLinkSectionProps> = (props: CommonLinkSectio
       const accounts: string[] = await window.ethereum.request({ method: 'eth_requestAccounts' })
       if (accounts.length > 0) {
         setAccounts(accounts)
-      } 
+      }
     }
     if (isConnected) getAccounts()
   }, [isConnected])
@@ -96,7 +101,11 @@ const BottomSection: React.FC<CommonLinkSectionProps> = (props: CommonLinkSectio
 
   return (
     <SectionWrapper>
-      {isConnected ? <AdditionalMenu accounts={accounts} toggle={props.toggle} userProfilePic={userProfilePic} /> : <WalletConnect MetaMaskInitialization={MetaMaskInitialization} />}
+      {isConnected ? (
+        <AdditionalMenu accounts={accounts} toggle={props.toggle} userProfilePic={userProfilePic} />
+      ) : (
+        <WalletConnect MetaMaskInitialization={MetaMaskInitialization} />
+      )}
     </SectionWrapper>
   )
 }

--- a/src/pages/CreateSingleNFT/CreateSingleNFT.tsx
+++ b/src/pages/CreateSingleNFT/CreateSingleNFT.tsx
@@ -302,6 +302,7 @@ const CreateSingleNFT = () => {
       setMintedContract(mintedNFT.address)
       setIsNFTMinted(true)
       setContractAddress(mintedNFT.address)
+      sessionStorage.setItem('contractAddress', mintedNFT.address)
     }
   }
 

--- a/src/pages/RoutesData.tsx
+++ b/src/pages/RoutesData.tsx
@@ -21,7 +21,6 @@ export const ROUTES = {
   NFT_VIEWER_OWNER: '/testnet/viewer-owner-LNFT',
   NFT_VIEWER_BUYER: '/testnet/viewer-buyer-LNFT',
   SHARE_IMPACT: '/testnet/impact-shareLNFT',
-  TRANSFER_SUCCESS: '/testnet/viewer-owner-transferLNFT',
   PROFILE_HANDLE: '/testnet/profile-handle',
   PROFILE_DASHBOARD: '/testnet/profile-dashboard',
   PROFILE_CREATOR_DASHBOARD: '/testnet/profile-creator-dashboard',
@@ -83,10 +82,6 @@ export const RoutesData = [
   {
     view: <ComposeImact />,
     path: ROUTES.COMPOSE_IMPACT,
-  },
-  {
-    view: <TransferSuccess />,
-    path: ROUTES.TRANSFER_SUCCESS,
   },
   {
     view: <NFTSettings />,

--- a/src/services/NFTService.ts
+++ b/src/services/NFTService.ts
@@ -48,6 +48,17 @@ class NFTService {
       console.log(value)
     })
   }
+
+  static async safeTransferFrom(contractAddress: string, tokenAbi: any, connection: any, from: string, to: string, id: number) {
+    const tokenContract = new ethers.Contract(contractAddress, tokenAbi, connection)
+    const signer = connection.getSigner()
+    const contract = tokenContract.connect(signer)
+    const transfer = await contract.safeTransferFrom(from, to, id)
+    const transferData = Promise.resolve(transfer)
+    transferData.then(value => {
+      console.log(value)
+    })
+  }
 }
 
 interface DeployProps {


### PR DESCRIPTION
1. The user address and contract address are initialized for each refresh. This is bad for UX and development so store the data into sessionStorage. The `getAccounts` method is called at the top-level (App.tsx) so that the log in is checked based on the sessionStorage

2. Update the transfer page : from link to modal

3. safeTransferFrom is not working
<img width="680" alt="Screenshot 2023-04-27 at 3 13 41 AM" src="https://user-images.githubusercontent.com/41753422/234669941-ab5e7dce-3663-49b2-9711-343ccc0e96d5.png">

